### PR TITLE
Add No results found message for empty search results

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,6 +11,16 @@ function saveNotes() {
 
 function renderNotes(filter = "") {
     notesGrid.innerHTML = "";
+    const filteredNotes = notes.filter(note =>
+    note.toLowerCase().includes(filter.toLowerCase())
+);
+
+if (filteredNotes.length === 0 && filter.trim() !== "") {
+    notesGrid.innerHTML = `<p style="text-align:center; margin-top:20px; color:#777;">
+        No notes found matching "${filter}"
+    </p>`;
+    return;
+}
     notes
         .filter(note => note.toLowerCase().includes(filter.toLowerCase()))
         .forEach((note, index) => {


### PR DESCRIPTION
## 📌 Description
Adds a user feedback message when no notes match the search query.
Previously, the UI displayed an empty grid without any indication when no results were found. This update improves the search UX by handling the empty search state.

---

## 🔗 Related Issue
Closes #8

---

## 🛠 Changes Made
- Added empty state handling inside renderNotes()
- Displayed “No notes found matching …” message when filtered results are empty
- Ensured message appears only when search input is not empty

---

## 📷 Screenshots (if applicable)
<img width="1908" height="924" alt="image" src="https://github.com/user-attachments/assets/9c326d68-0678-4fda-a5ef-842f4efc4248" />

---

## ✅ Checklist
- [x ] I have tested my changes
- [x ] My code follows project guidelines
- [x ] I have linked the related issue
