### PR TITLE
confirmation box added

### DIFF
--- a/script.js
+++ b/script.js
@@ -70,6 +70,7 @@ function addNote() {
 }
 
 function deleteNote(index) {
+     if (!confirm("Move this note to trash?")) return;
     trash.push(notes[index]);   // move to trash instead of permanent delete
     notes.splice(index, 1);
     saveNotes();
@@ -100,6 +101,7 @@ function restoreNote(index) {
 }
 
 function permanentlyDelete(index) {
+     if (!confirm("Permanently delete this note? This cannot be undone.")) return;
     trash.splice(index, 1);
     saveTrash();
     renderTrash();


### PR DESCRIPTION
## 📌 Description
Adds a confirmation dialog before deleting notes to prevent accidental data loss. Users are prompted before moving a note to trash, and again before permanently deleting from trash.

---

## 🔗 Related Issue
Closes #6

---

## 🛠 Changes Made
- Added `confirm()` prompt in `deleteNote()` before moving a note to trash
- Added `confirm()` prompt in `permanentlyDelete()` before permanently removing a note

---

## 📷 Screenshots (if applicable)

<img width="1368" height="768" alt="Screenshot from 2026-02-22 12-00-52" src="https://github.com/user-attachments/assets/4ba08b35-e548-4845-831d-cfbd019335d2" />


---

## ✅ Checklist
- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue